### PR TITLE
Avoid restarting whole app before DB update

### DIFF
--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -99,6 +99,14 @@ then
     checkOutputDirExists
     downloadRunFile
     $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION
+elif [ "$1" == "updateapp" ]
+then
+    checkOutputDirExists
+    # docker-compose project name has been introduced in a new run.sh script, so we need
+    # to stop an instance which should have been started before without a project name.
+    grep -q COMPOSE_PROJECT_NAME $SCRIPTS_DIR/run.sh || $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
+    downloadRunFile
+    $SCRIPTS_DIR/run.sh updateapp $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "updatedb" ]
 then
     checkOutputDirExists

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,9 +39,9 @@ LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
 function dockerComposeUp() {
     if [ -f "${DOCKER_DIR}/docker-compose.override.yml" ]
     then
-        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d $1
     else
-        docker-compose -f $DOCKER_DIR/docker-compose.yml up -d
+        docker-compose -f $DOCKER_DIR/docker-compose.yml up -d $1
     fi
 }
 
@@ -131,7 +131,7 @@ function restart() {
         (echo $LUID; echo $LGID) > $ENV_DIR/uid.env
     fi
     
-    dockerComposeUp
+    dockerComposeUp $1
     dockerPrune
     printEnvironment
 }
@@ -145,21 +145,26 @@ function pullSetup() {
 if [ "$1" == "start" -o "$1" == "restart" ]
 then
     restart
-elif [ "$1" == "pull" ]
-then
-    dockerComposePull
 elif [ "$1" == "stop" ]
 then
     dockerComposeDown
+elif [ "$1" == "updateapp" ]
+then
+    dockerComposeDown
+    update
 elif [ "$1" == "updatedb" ]
 then
+    restart mssql
+    echo "Pausing 60 seconds for database to come online. Please wait..."
+    sleep 60
     updateDatabase
 elif [ "$1" == "update" ]
 then
     dockerComposeDown
     update
-    restart
+    restart mssql
     echo "Pausing 60 seconds for database to come online. Please wait..."
     sleep 60
     updateDatabase
+    restart
 fi


### PR DESCRIPTION
Hi,

This PR modifies the update procedure so that the whole app is not restarted until DB is updated.

Thx !